### PR TITLE
Update Nginx configuration for HTTPS enforcement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# Use a lightweight server to serve the static files.
+# Use an official Nginx image to serve the app
 FROM nginx:alpine
 
-# Copy built files from the previous stage to the nginx directory.
+# Copy the built files from your local dist directory to the Nginx HTML directory
 COPY ./dist /usr/share/nginx/html
 
 # Copy the custom Nginx configuration file
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose the port for the server.
-EXPOSE 80
+# Expose port 443 for SSL
+EXPOSE 443
 
-# Command to run Nginx.
+# Command to run Nginx in the foreground
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,11 +1,14 @@
 server {
-    listen 80;
+    listen 443 ssl;
     server_name localhost;
+
+    ssl_certificate /etc/letsencrypt/live/hlc.cs.smu.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hlc.cs.smu.ca/privkey.pem;
 
     location / {
         root /usr/share/nginx/html;  # Path to your static files
         index index.html index.htm;
-        try_files $uri $uri/ /index.html;  # Redirect all other requests to index.html
+        try_files $uri $uri/ /index.html;
     }
 
     error_page 404 /404.html;  # Optional: Custom error page


### PR DESCRIPTION
- Removed HTTP (port 80) exposure and redirection, ensuring the application only serves traffic over HTTPS.
- Updated Nginx configuration to use Let's Encrypt certificates for secure connections.
- Adjusted Dockerfile to copy Let's Encrypt certificates and expose only port 443.